### PR TITLE
Misc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@ pub struct Layer {
 impl Layer {
     /// Return the descriptor for this layer
     pub fn descriptor(&self) -> oci_image::DescriptorBuilder {
-        self.blob.descriptor()
+        self.blob.descriptor().media_type(MediaType::ImageLayerGzip)
     }
 }
 
@@ -297,7 +297,7 @@ impl OciDir {
         description: &str,
         created: chrono::DateTime<chrono::Utc>,
     ) {
-        let mut builder = layer.descriptor().media_type(MediaType::ImageLayerGzip);
+        let mut builder = layer.descriptor();
         if let Some(annotations) = annotations {
             builder = builder.annotations(annotations);
         }
@@ -341,7 +341,7 @@ impl OciDir {
     /// Returns `true` if the blob with this digest is already present.
     pub fn has_blob(&self, desc: &oci_spec::image::Descriptor) -> Result<bool> {
         let path = Self::parse_descriptor_to_path(desc)?;
-        self.dir.try_exists(&path).map_err(Into::into)
+        self.dir.try_exists(path).map_err(Into::into)
     }
 
     /// Returns `true` if the manifest is already present.
@@ -679,11 +679,7 @@ mod tests {
         let mut layerw = w.create_gzip_layer(None)?;
         layerw.write_all(b"pretend this is a tarball")?;
         let root_layer = layerw.complete()?;
-        let root_layer_desc = root_layer
-            .descriptor()
-            .media_type(MediaType::ImageLayerGzip)
-            .build()
-            .unwrap();
+        let root_layer_desc = root_layer.descriptor().build().unwrap();
         assert_eq!(
             root_layer.uncompressed_sha256,
             "349438e5faf763e8875b43de4d7101540ef4d865190336c2cc549a11f33f8d7c"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,6 +56,8 @@ use std::path::{Path, PathBuf};
 pub use cap_std_ext::cap_std;
 pub use oci_spec;
 
+/// The digest identifier for SHA-256
+const SHA256_NAME: &str = "sha256";
 /// Path inside an OCI directory to the blobs
 const BLOBDIR: &str = "blobs/sha256";
 /// Length of a hex-formatted sha256
@@ -75,7 +77,7 @@ pub struct Blob {
 impl Blob {
     /// The OCI standard checksum-type:checksum
     pub fn digest_id(&self) -> String {
-        format!("sha256:{}", self.sha256)
+        format!("{SHA256_NAME}:{}", self.sha256)
     }
 
     /// Descriptor
@@ -173,7 +175,9 @@ fn empty_config_descriptor() -> oci_image::Descriptor {
     oci_image::DescriptorBuilder::default()
         .media_type(MediaType::ImageConfig)
         .size(7023)
-        .digest("sha256:a5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7")
+        .digest(format!(
+            "{SHA256_NAME}:a5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7"
+        ))
         .build()
         .unwrap()
 }
@@ -281,7 +285,7 @@ impl OciDir {
         let mut rootfs = config.rootfs().clone();
         rootfs
             .diff_ids_mut()
-            .push(format!("sha256:{}", layer.uncompressed_sha256));
+            .push(format!("{SHA256_NAME}:{}", layer.uncompressed_sha256));
         config.set_rootfs(rootfs);
         let now = chrono::offset::Utc::now();
         let h = oci_image::HistoryBuilder::default()
@@ -298,7 +302,7 @@ impl OciDir {
             .split_once(':')
             .ok_or_else(|| anyhow!("Invalid digest {}", desc.digest()))?;
         let alg = parse_one_filename(alg)?;
-        if alg != "sha256" {
+        if alg != SHA256_NAME {
             anyhow::bail!("Unsupported digest algorithm {}", desc.digest());
         }
         let hash = parse_one_filename(hash)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,11 @@ impl OciDir {
         write_json_blob(&self.dir, v, media_type)
     }
 
+    /// Create a blob (can be anything).
+    pub fn create_blob(&self) -> Result<BlobWriter> {
+        BlobWriter::new(&self.dir)
+    }
+
     /// Create a writer for a new gzip+tar blob; the contents
     /// are not parsed, but are expected to be a tarball.
     pub fn create_gzip_layer(&self, c: Option<flate2::Compression>) -> Result<GzipLayerWriter> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -315,7 +315,7 @@ impl OciDir {
     }
 
     /// Read a JSON blob.
-    pub fn read_json_blob<T: serde::de::DeserializeOwned + Send + 'static>(
+    pub fn read_json_blob<T: serde::de::DeserializeOwned>(
         &self,
         desc: &oci_spec::image::Descriptor,
     ) -> Result<T> {


### PR DESCRIPTION
read_json_blob: Drop unnecessary constraints

Just noted this while scrolling by.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lib: Create a const for sha256

Just a cleanup.

Signed-off-by: Colin Walters <walters@verbum.org>

---

lib: Add an API to write layers with timestamps

I didn't have an immediate use case, I was just reading
the code for unrelated reasons and noticed this.

But I'm sure we'd want this for reproducible builds.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Add functions to query existence of manifests and blobs

This is useful for tooling that wants to check before e.g.
fetching.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Add a function to create a raw blob

This is needed for things that want to copy in external
data.

Signed-off-by: Colin Walters <walters@verbum.org>

---

Automatically set gzip media type on layer descriptor

This is a sane thing to default.

Signed-off-by: Colin Walters <walters@verbum.org>

---