### PR TITLE
lib: Update to oci-spec 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ocidir"
 description = "A Rust library for reading and writing OCI (opencontainers) layout directories"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/containers/ocidir-rs"
@@ -20,4 +20,4 @@ openssl = "0.10.33"
 serde = { features = ["derive"], version = "1.0.125" }
 serde_json = "1.0.64"
 tar = "0.4.38"
-oci-spec = "0.6.5"
+oci-spec = "0.7.0"


### PR DESCRIPTION
There are a few semver breaks there, but I helped drive them because they clean up the codebase here.

Most notably:

- We have hardened upstream "verify descriptor is sha256:" logic
- size is now properly u64

etc.