### PR TITLE
Add support for symlinks in blobs/sha256 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To access an existing OCI directory:
 # use anyhow::{anyhow, Result};
 # fn main() -> anyhow::Result<()> {
 let d = cap_std::fs::Dir::open_ambient_dir("/path/to/ocidir", cap_std::ambient_authority())?;
-let d = ocidir::OciDir::open(&d)?;
+let d = ocidir::OciDir::open(d)?;
 println!("{:?}", d.read_index()?.ok_or_else(|| anyhow!("missing Image Index"))?);
 # Ok(())
 # }


### PR DESCRIPTION
This feature is especially useful when we want to share blobs across OCI repositories. See the `--dest-shared-blob-dir` option in skopeo [1] as well as the LXC OCI template [2] (specifically OCI_USE_CACHE).

closes #21

[1] https://github.com/containers/skopeo/blob/main/docs/skopeo-copy.1.md
[2] https://github.com/lxc/lxc/blob/main/templates/lxc-oci.in