### PR TITLE
allow users to get ZstdLayerWriter directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
       - name: cargo build
-        run: cargo build --all-targets
+        run: cargo build --all-targets --all-features
       - name: cargo test
         run: cargo test --all-targets
       # https://github.com/rust-lang/cargo/issues/6669

--- a/examples/zstd.rs
+++ b/examples/zstd.rs
@@ -5,7 +5,7 @@ fn main() {
     use oci_spec::image::Platform;
     use ocidir::{cap_std::fs::Dir, new_empty_manifest, OciDir};
     let dir = Dir::open_ambient_dir(env::temp_dir(), ocidir::cap_std::ambient_authority()).unwrap();
-    let oci_dir = OciDir::ensure(&dir).unwrap();
+    let oci_dir = OciDir::ensure(dir).unwrap();
 
     let mut manifest = new_empty_manifest().build().unwrap();
     let mut config = ocidir::oci_spec::image::ImageConfigurationBuilder::default()
@@ -13,23 +13,28 @@ fn main() {
         .unwrap();
 
     // Add the src as a layer
-    let mut writer = oci_dir.create_layer_zstd(Some(0)).unwrap();
-    writer
+    let writer = oci_dir.create_layer_zstd(Some(0)).unwrap();
+    let mut builder = tar::Builder::new(writer);
+    builder.follow_symlinks(false);
+
+    builder
         .append_dir_all(".", PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src"))
         .unwrap();
 
-    let layer = writer.into_inner().unwrap().complete().unwrap();
+    let layer = builder.into_inner().unwrap().complete().unwrap();
     oci_dir.push_layer(&mut manifest, &mut config, layer, "src", None);
 
     // Add the examples as a layer, using multithreaded compression
-    let mut writer = oci_dir.create_layer_zstd_multithread(Some(0), 4).unwrap();
-    writer
+    let writer = oci_dir.create_layer_zstd_multithread(Some(0), 4).unwrap();
+    let mut builder = tar::Builder::new(writer);
+    builder.follow_symlinks(false);
+    builder
         .append_dir_all(
             ".",
             PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples"),
         )
         .unwrap();
-    let layer = writer.into_inner().unwrap().complete().unwrap();
+    let layer = builder.into_inner().unwrap().complete().unwrap();
     oci_dir.push_layer(&mut manifest, &mut config, layer, "examples", None);
 
     println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,22 +276,18 @@ impl OciDir {
     }
 
     #[cfg(feature = "zstd")]
-    /// Create a tar output stream, backed by a zstd compressed blob
+    /// Create a writer for a new zstd+tar blob; the contents
+    /// are not parsed, but are expected to be a tarball.
     ///
     /// This method is only available when the `zstd` feature is enabled.
-    pub fn create_layer_zstd(
-        &self,
-        compression_level: Option<i32>,
-    ) -> Result<tar::Builder<ZstdLayerWriter>> {
-        Ok(tar::Builder::new(ZstdLayerWriter::new(
-            &self.dir,
-            compression_level,
-        )?))
+    pub fn create_layer_zstd(&self, compression_level: Option<i32>) -> Result<ZstdLayerWriter> {
+        Ok(ZstdLayerWriter::new(&self.dir, compression_level)?)
     }
 
     #[cfg(feature = "zstdmt")]
-    /// Create a tar output stream, backed by a zstd compressed blob
-    /// using multithreaded compression.
+    /// Create a writer for a new zstd+tar blob; the contents
+    /// are not parsed, but are expected to be a tarball.
+    /// The compression is multithreaded.
     ///
     /// The `n_workers` parameter specifies the number of threads to use for compression, per
     /// [zstd::Encoder::multithread]]
@@ -301,12 +297,12 @@ impl OciDir {
         &self,
         compression_level: Option<i32>,
         n_workers: u32,
-    ) -> Result<tar::Builder<ZstdLayerWriter>> {
-        Ok(tar::Builder::new(ZstdLayerWriter::multithread(
+    ) -> Result<ZstdLayerWriter> {
+        Ok(ZstdLayerWriter::multithread(
             &self.dir,
             compression_level,
             n_workers,
-        )?))
+        )?)
     }
 
     /// Add a layer to the top of the image stack.  The firsh pushed layer becomes the root.


### PR DESCRIPTION
... rather than wrapping in a tar builder. Apologies for missing this in https://github.com/containers/ocidir-rs/pull/24

In rpmoci I'm wanting to give the user a choice of gzip or zstd compression. I want to create an enum like

```rust
enum LayerWriter<'a> {
    Gzip(ocidir::GzipLayerWriter<'a>),
    Zstd(ocidir::ZstdLayerWriter<'a>),
}

impl<'a> Write for LayerWriter<'a> {
    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
        match self {
            Self::Gzip(writer) => writer.write(buf),
            Self::Zstd(writer) => writer.write(buf),
        }
    }

    fn flush(&mut self) -> std::io::Result<()> {
        match self {
            Self::Gzip(writer) => writer.flush(),
            Self::Zstd(writer) => writer.flush(),
        }
    }
}
```

I'll then create a `tar::Builder<LayerWriter<'a>>`. But I can't currently create an ZstdLayerWriter.