### PR TITLE
new_empty_manifest: create a valid manifest with an empty config desc…

### DIFF
--- a/examples/zstd.rs
+++ b/examples/zstd.rs
@@ -4,11 +4,11 @@ fn main() {
 
     use cap_tempfile::TempDir;
     use oci_spec::image::Platform;
-    use ocidir::{new_empty_manifest, OciDir};
+    use ocidir::OciDir;
     let dir = TempDir::new(ocidir::cap_std::ambient_authority()).unwrap();
     let oci_dir = OciDir::ensure(dir.try_clone().unwrap()).unwrap();
 
-    let mut manifest = new_empty_manifest().build().unwrap();
+    let mut manifest = oci_dir.new_empty_manifest().unwrap().build().unwrap();
     let mut config = ocidir::oci_spec::image::ImageConfigurationBuilder::default()
         .build()
         .unwrap();


### PR DESCRIPTION
…riptor

The empty descriptor is described in the image spec [1]. `new_empty_manifest` writes an empty config descriptor in the blobs directory, which results in a valid image layout specification. This is validated using the fsck function in the `test_new_empty_manifest` test.

Fixes #27

[1] https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidance-for-an-empty-descriptor