### PR TITLE
Switch to canon-json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   # Pinned toolchain for linting
-  ACTIONS_LINTS_TOOLCHAIN: 1.76.0
+  ACTIONS_LINTS_TOOLCHAIN: 1.86.0
 
 jobs:
   tests-stable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ keywords = ["oci", "opencontainers", "docker", "podman", "containers"]
 [dependencies]
 camino = "1.0.4"
 chrono = "0.4.19"
-olpc-cjson = "0.1.1"
 cap-std-ext = "4.0"
 flate2 = { features = ["zlib"], default-features = false, version = "1.0.20" }
 hex = "0.4.3"
@@ -21,6 +20,7 @@ tar = "0.4.38"
 thiserror = "2"
 oci-spec = "0.7.0"
 zstd = { version = "0.13.2", optional = true }
+canon-json = "0.2.0"
 
 [dev-dependencies]
 anyhow = "1.0.89"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 
+use canon_json::CanonicalFormatter;
 use cap_std::fs::{Dir, DirBuilderExt};
 use cap_std_ext::cap_tempfile;
 use cap_std_ext::dirext::CapStdExtDirExt;
@@ -9,7 +10,6 @@ use oci_spec::image::{
     self as oci_image, Descriptor, Digest, ImageConfiguration, ImageIndex, ImageManifest,
     Sha256Digest,
 };
-use olpc_cjson::CanonicalFormatter;
 use openssl::hash::{Hasher, MessageDigest};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,7 @@ pub struct BlobWriter<'a> {
     size: u64,
 }
 
-impl<'a> Debug for BlobWriter<'a> {
+impl Debug for BlobWriter<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlobWriter")
             .field("target", &self.target)
@@ -698,7 +698,7 @@ impl<'a> BlobWriter<'a> {
     }
 }
 
-impl<'a> std::io::Write for BlobWriter<'a> {
+impl std::io::Write for BlobWriter<'_> {
     fn write(&mut self, srcbuf: &[u8]) -> std::io::Result<usize> {
         self.hash.update(srcbuf)?;
         self.target
@@ -735,7 +735,7 @@ impl<'a> GzipLayerWriter<'a> {
     }
 }
 
-impl<'a> std::io::Write for GzipLayerWriter<'a> {
+impl std::io::Write for GzipLayerWriter<'_> {
     fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
         self.0.write(data)
     }
@@ -781,7 +781,7 @@ impl<'a> ZstdLayerWriter<'a> {
 }
 
 #[cfg(feature = "zstd")]
-impl<'a> std::io::Write for ZstdLayerWriter<'a> {
+impl std::io::Write for ZstdLayerWriter<'_> {
     fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
         self.0.write(data)
     }


### PR DESCRIPTION
canon-json provides a serde_json Formatter to serialize as RFC 8785 canonical JSON.
It's a drop in replacement for olpc-cjson.

Fix #10 