### PR TITLE
Updates for oci-spec 0.8.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ocidir"
 description = "A Rust library for reading and writing OCI (opencontainers) layout directories"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/containers/ocidir-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ocidir"
 description = "A Rust library for reading and writing OCI (opencontainers) layout directories"
 version = "0.5.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/containers/ocidir-rs"
 keywords = ["oci", "opencontainers", "docker", "podman", "containers"]

--- a/examples/custom_compressor.rs
+++ b/examples/custom_compressor.rs
@@ -3,7 +3,7 @@
 use std::{env, io, path::PathBuf};
 
 use oci_spec::image::Platform;
-use ocidir::{cap_std::fs::Dir, BlobWriter, OciDir, WriteComplete};
+use ocidir::{BlobWriter, OciDir, WriteComplete, cap_std::fs::Dir};
 
 struct NoCompression<'a>(BlobWriter<'a>);
 

--- a/examples/ocidir-import-tar.rs
+++ b/examples/ocidir-import-tar.rs
@@ -42,7 +42,12 @@ fn import(oci_dir: &OciDir, name: &str, src: File) -> anyhow::Result<()> {
         .created_by(name.to_string())
         .build()
         .unwrap();
-    config.history_mut().push(h);
+    match config.history_mut() {
+        Some(v) => v.push(h),
+        None => {
+            config.set_history(Some(vec![h]));
+        }
+    }
 
     println!(
         "Created image with manifest: {}",


### PR DESCRIPTION
oci-spec 0.8.2 has made a breaking change to it's `config` API changing the `history` field to be Optional to align with the OCI spec, see https://github.com/youki-dev/oci-spec-rs/pull/288. 

I've made changes here to accommodate this change and tagged as 0.6.0 as this is breaking change to the API of ocidir.

Whilst in the area I've run cargo fmt and fixed up some clippy warnings about elided lifetimes.

Q for reviewer, should this be released at 0.5.1 so downstream consumers can take the fix without needing to make changes?